### PR TITLE
[FLINK-26941][cep] Support Pattern end with notFollowedBy in case tim…

### DIFF
--- a/docs/content.zh/docs/libs/cep.md
+++ b/docs/content.zh/docs/libs/cep.md
@@ -621,7 +621,7 @@ val start : Pattern[Event, _] = Pattern.begin("start")
 2. `notFollowedBy()`，如果不想一个特定事件发生在两个事件之间的任何地方。
 
 {{< hint warning >}}
-模式序列不能以`notFollowedBy()`结尾。
+如果模式序列没有定义时间约束，则不能以 `notFollowedBy()` 结尾。
 {{< /hint >}}
 
 {{< hint warning >}}
@@ -697,6 +697,35 @@ next.within(Time.seconds(10));
 {{< tab "Scala" >}}
 ```scala
 next.within(Time.seconds(10))
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+注意定义过时间约束的模式允许以 `notFollowedBy()` 结尾。
+例如，可以定义如下的模式:
+
+{{< tabs "df27eb6d-c532-430a-b56f-98ad4082e6d5" >}}
+{{< tab "Java" >}}
+```java
+Pattern.<Event>begin("start")
+    .next("middle").where(new SimpleCondition<Event>() {
+    @Override
+    public boolean filter(Event value) throws Exception {
+        return value.getName().equals("a");
+    }
+}).notFollowedBy("end").where(new SimpleCondition<Event>() {
+    @Override
+    public boolean filter(Event value) throws Exception {
+        return value.getName().equals("b");
+    }
+}).within(Time.seconds(10));
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+Pattern.begin("start").where(_.getName().equals("a"))
+.notFollowedBy("end").where(_.getName == "b")
+.within(Time.seconds(10))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/libs/cep.md
+++ b/docs/content/docs/libs/cep.md
@@ -636,7 +636,7 @@ or
 2. `notFollowedBy()`, if you do not want an event type to be anywhere between two other event types.
 
 {{< hint warning >}}
-A pattern sequence cannot end in `notFollowedBy()`.
+A pattern sequence cannot end with `notFollowedBy()` if the time interval is not defined via `withIn()`.
 {{< /hint >}}
 
 {{< hint warning >}}
@@ -714,6 +714,35 @@ next.within(Time.seconds(10));
 {{< tab "Scala" >}}
 ```scala
 next.within(Time.seconds(10))
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+Notice that a pattern sequence can end with `notFollowedBy()` with temporal constraint
+E.g. a pattern like:
+
+{{< tabs "df27eb6d-c532-430a-b56f-98ad4082e6d5" >}}
+{{< tab "Java" >}}
+```java
+Pattern.<Event>begin("start")
+    .next("middle").where(new SimpleCondition<Event>() {
+    @Override
+    public boolean filter(Event value) throws Exception {
+        return value.getName().equals("a");
+    }
+}).notFollowedBy("end").where(new SimpleCondition<Event>() {
+    @Override
+    public boolean filter(Event value) throws Exception {
+        return value.getName().equals("b");
+    }
+}).within(Time.seconds(10));
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+Pattern.begin("start").where(_.getName().equals("a"))
+.notFollowedBy("end").where(_.getName == "b")
+.within(Time.seconds(10))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
@@ -135,11 +135,16 @@ public class State<T> implements Serializable {
         return stateType == StateType.Stop;
     }
 
+    public boolean isPending() {
+        return stateType == StateType.Pending;
+    }
+
     /** Set of valid state types. */
     public enum StateType {
         Start, // the state is a starting state for the NFA
         Final, // the state is a final state for the NFA
         Normal, // the state is neither a start nor a final state
+        Pending, // the state is pending and waiting for timeout handling
         Stop
     }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
@@ -210,7 +210,7 @@ public class NFAStatusChangeITCase {
         // be removed from eventSharedBuffer as the timeout happens
         nfaState.resetStateChanged();
         Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutResults =
-                nfa.advanceTime(sharedBufferAccessor, nfaState, 12L);
+                nfa.advanceTime(sharedBufferAccessor, nfaState, 12L).f1;
         assertTrue(
                 "NFA status should change as timeout happens",
                 nfaState.isStateChanged() && !timeoutResults.isEmpty());

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.cep.nfa;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.TestLogger;
 
@@ -1508,5 +1509,121 @@ public class NotPatternITCase extends TestLogger {
         NFA<Event> nfa = compile(pattern, false);
 
         return feedNFA(inputEvents, nfa);
+    }
+
+    @Test
+    public void testNotFollowedByWithInAtEnd() throws Exception {
+        List<StreamRecord<Event>> inputEvents = new ArrayList<>();
+
+        Event a1 = new Event(40, "a", 1.0);
+        Event b1 = new Event(41, "b", 2.0);
+        Event a2 = new Event(42, "a", 3.0);
+        Event c = new Event(43, "c", 4.0);
+        Event b2 = new Event(44, "b", 5.0);
+        Event a3 = new Event(46, "a", 7.0);
+        Event b3 = new Event(47, "b", 8.0);
+
+        inputEvents.add(new StreamRecord<>(a1, 1));
+        inputEvents.add(new StreamRecord<>(b1, 2));
+        inputEvents.add(new StreamRecord<>(a2, 4));
+        inputEvents.add(new StreamRecord<>(c, 5));
+        inputEvents.add(new StreamRecord<>(b2, 10));
+        inputEvents.add(new StreamRecord<>(a3, 11));
+        inputEvents.add(new StreamRecord<>(b3, 13));
+
+        Pattern<Event, ?> pattern =
+                Pattern.<Event>begin("a")
+                        .where(
+                                new SimpleCondition<Event>() {
+
+                                    @Override
+                                    public boolean filter(Event value) throws Exception {
+                                        return value.getName().equals("a");
+                                    }
+                                })
+                        .notFollowedBy("b")
+                        .where(
+                                new SimpleCondition<Event>() {
+
+                                    @Override
+                                    public boolean filter(Event value) throws Exception {
+                                        return value.getName().equals("b");
+                                    }
+                                })
+                        .within(Time.milliseconds(3));
+
+        NFA<Event> nfa = compile(pattern, false);
+
+        final List<List<Event>> matches = feedNFA(inputEvents, nfa);
+
+        comparePatterns(matches, Lists.<List<Event>>newArrayList(Lists.newArrayList(a2)));
+    }
+
+    @Test
+    public void testNotFollowByBeforeTimesWithIn() throws Exception {
+        List<StreamRecord<Event>> inputEvents = new ArrayList<>();
+
+        Event a1 = new Event(40, "a", 1.0);
+        Event b1 = new Event(41, "b", 2.0);
+        Event a2 = new Event(42, "a", 3.0);
+        Event c1 = new Event(43, "c", 4.0);
+        Event c2 = new Event(44, "c", 5.0);
+        Event a3 = new Event(46, "a", 7.0);
+        Event c3 = new Event(47, "c", 8.0);
+        Event c4 = new Event(47, "c", 8.0);
+
+        inputEvents.add(new StreamRecord<>(a1, 1));
+        inputEvents.add(new StreamRecord<>(b1, 2));
+        inputEvents.add(new StreamRecord<>(a2, 10));
+        inputEvents.add(new StreamRecord<>(c1, 11));
+        inputEvents.add(new StreamRecord<>(c2, 12));
+        inputEvents.add(new StreamRecord<>(a3, 20));
+        inputEvents.add(new StreamRecord<>(c3, 21));
+        inputEvents.add(new StreamRecord<>(c4, 24));
+
+        Pattern<Event, ?> pattern =
+                Pattern.<Event>begin("a")
+                        .where(
+                                new SimpleCondition<Event>() {
+
+                                    @Override
+                                    public boolean filter(Event value) throws Exception {
+                                        return value.getName().equals("a");
+                                    }
+                                })
+                        .notFollowedBy("b")
+                        .where(
+                                new SimpleCondition<Event>() {
+
+                                    @Override
+                                    public boolean filter(Event value) throws Exception {
+                                        return value.getName().equals("b");
+                                    }
+                                })
+                        .followedBy("c")
+                        .where(
+                                new SimpleCondition<Event>() {
+
+                                    @Override
+                                    public boolean filter(Event value) throws Exception {
+                                        return value.getName().equals("c");
+                                    }
+                                })
+                        .times(0, 2)
+                        .within(Time.milliseconds(3));
+
+        NFA<Event> nfa = compile(pattern, false);
+
+        final List<List<Event>> matches = feedNFA(inputEvents, nfa);
+
+        comparePatterns(
+                matches,
+                Lists.<List<Event>>newArrayList(
+                        Lists.newArrayList(a1),
+                        Lists.newArrayList(a2),
+                        Lists.newArrayList(a2, c1),
+                        Lists.newArrayList(a2, c1, c2),
+                        Lists.newArrayList(a3),
+                        Lists.newArrayList(a3, c4)));
     }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestHarness.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestHarness.java
@@ -99,14 +99,18 @@ public final class NFATestHarness {
     public Collection<Map<String, List<Event>>> consumeRecord(StreamRecord<Event> inputEvent)
             throws Exception {
         try (SharedBufferAccessor<Event> sharedBufferAccessor = sharedBuffer.getAccessor()) {
-            nfa.advanceTime(sharedBufferAccessor, nfaState, inputEvent.getTimestamp());
-            return nfa.process(
-                    sharedBufferAccessor,
-                    nfaState,
-                    inputEvent.getValue(),
-                    inputEvent.getTimestamp(),
-                    afterMatchSkipStrategy,
-                    timerService);
+            Collection<Map<String, List<Event>>> pendingMatches =
+                    nfa.advanceTime(sharedBufferAccessor, nfaState, inputEvent.getTimestamp()).f0;
+            Collection<Map<String, List<Event>>> matchedPatterns =
+                    nfa.process(
+                            sharedBufferAccessor,
+                            nfaState,
+                            inputEvent.getValue(),
+                            inputEvent.getTimestamp(),
+                            afterMatchSkipStrategy,
+                            timerService);
+            matchedPatterns.addAll(pendingMatches);
+            return matchedPatterns;
         }
     }
 


### PR DESCRIPTION
…e constraint is defined

This closes #19295.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
